### PR TITLE
Installation cmd doesn't work. Wrong git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can use the provided Dockerfile which will compile a binary for you or build
 yourself.
 
 ```bash
-docker build -t docker-volumes git@github.com:cpuguy83/docker-volumes.git
+docker build -t docker-volumes https://github.com/cpuguy83/docker-volumes.git
 docker run --name docker-volumes docker-volumes
 docker cp docker-volumes:/docker-volumes ./
 ```
@@ -59,7 +59,7 @@ Alternatively, if you already have golang installed on your system you can
 compile it yourself:
 
 ```bash
-git clone git@github.com:cpuguy83/docker-volumes.git
+git clone https://github.com/cpuguy83/docker-volumes.git
 cd docker-volumes
 go get
 go build


### PR DESCRIPTION
Fixes #14

    $ docker build -t docker-volumes git@github,com:cpuguy83/docker-volumes.git
    FATA[0001] Error trying to use git: exit status 128 (Cloining into '/tmp/docker-build-git389505117'…
    Permission denied (publickey).
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.
    )