### PR TITLE
Fixing volume ID output in quiet mode.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -21,7 +21,7 @@ func volumeList(ctx *cli.Context) {
 	if ctx.Bool("quiet") {
 		var out []string
 		for _, vol := range volumes.s {
-			id := vol.Id()
+			id := vol.ID
 			out = append(out, id)
 		}
 		fmt.Fprintln(os.Stdout, strings.Join(out, "\n"))


### PR DESCRIPTION
Listing volumes in quiet mode uses `Id()` rather than `ID`, which seems to be handled differently for mounted volumes. This means you cannot use the output of `docker-volumes list -q` to identify volumes to export.

```
docker-volumes list
       ID      |                NAMES                |                                               PATH                                                 
+--------------+-------------------------------------+---------------------------------------------------------------------------------------------------+
  ea6c68e6d15c | web_dockerui_1:/var/run/docker.sock | /var/run/docker.sock                                                                               
  96dd15392a4a | web_nginx_1:/etc/nginx/certs        | /mnt/sda1/var/lib/docker/vfs/dir/96dd15392a4ab193b0e4e6984c50078a6fbc89b3525d03200345dcc81803a371  
```

Before:

```
docker-volumes list -q
9d11d687c175f9869983aabb962ea2346aea69da9c1dc2c175828218cf23d0b9
docker.sock
```

After:

```
docker-volumes list -q
9d11d687c175f9869983aabb962ea2346aea69da9c1dc2c175828218cf23d0b9
ea6c68e6d15cfad87656d889a13b56377d13e174
```
